### PR TITLE
[campaignion_conf] remove auto break from html filter

### DIFF
--- a/modules/campaignion_conf/campaignion_conf.features.filter.inc
+++ b/modules/campaignion_conf/campaignion_conf.features.filter.inc
@@ -28,11 +28,6 @@ function campaignion_conf_filter_default_formats() {
         'status' => 1,
         'settings' => array(),
       ),
-      'filter_autop' => array(
-        'weight' => -48,
-        'status' => 1,
-        'settings' => array(),
-      ),
       'filter_url' => array(
         'weight' => -47,
         'status' => 1,


### PR DESCRIPTION
When using a WYSIWYG, it already takes care of breaks and paragraphs, but when writing HTML outside a WYSIWYG (e.g. in a markup form field) it's usually not desired and extremely annoying if `<br>` and `<p>` tags are being added automatically. Users who do not want to write HTML may choose the option "plain text" instead.

Identical to https://github.com/moreonion/campaignion_starterkit/pull/65