### PR TITLE
[Supporter] Fix too long MailChimp merge tags.

### DIFF
--- a/modules/campaignion_supporter/src/Supporter.php
+++ b/modules/campaignion_supporter/src/Supporter.php
@@ -80,6 +80,7 @@ class Supporter implements ContactTypeInterface {
         $map['dev_country'] = new TagField('mp_country');
         break;
       case 'mailchimp':
+        // MailChimp merge tags have a maximum of 10 characters.
         $map['EMAIL'] = new WrapperField('email');
         $map['FNAME'] = new SingleValueField('first_name');
         $map['LNAME'] = new SingleValueField('last_name');
@@ -100,7 +101,7 @@ class Supporter implements ContactTypeInterface {
         $map['MP_CONST'] = new WrapperField('mp_constituency');
         $map['MP_PARTY'] = new TagField('mp_party');
         $map['MP_NAME'] = new WrapperField('mp_salutation');
-        $map['DEV_COUNTRY'] = new TagField('mp_country');
+        $map['DVCOUNTRY'] = new TagField('mp_country');
         break;
       case 'campaignion_manage':
         $address_mapping = array(


### PR DESCRIPTION
MailChimp merge tags must not be longer than 10 characters.

Original commits dealing with this issue: https://github.com/moreonion/campaignion_starterkit_uk/pull/6/commits/41993273ff51efa948201b84342216dba705af50, https://github.com/moreonion/campaignion_starterkit_uk/pull/6/commits/bf69e5bd83ce06096088ba7240c7e563b0c69b37