### PR TITLE
Remove Share Ask from Thank you email

### DIFF
--- a/modules/campaignion_donation_type/campaignion_donation_type.features.uuid_node.inc
+++ b/modules/campaignion_donation_type/campaignion_donation_type.features.uuid_node.inc
@@ -126,7 +126,6 @@ function campaignion_donation_type_uuid_features_default_content() {
         'from_address' => 'default',
         'template' => '<p>Hi [submission:values:first_name],</p>
 <p>Thank you for supporting us with your donation of [submission:values:donation_amount]!</p>
-<p>Remember: sharing is caring :-)</p>
 <p>Have a great day!<br>
 	Your Supporter Service Team</p>',
         'excluded_components' => array(),

--- a/modules/campaignion_email_protest_type/campaignion_email_protest_type.features.uuid_node.inc
+++ b/modules/campaignion_email_protest_type/campaignion_email_protest_type.features.uuid_node.inc
@@ -134,7 +134,6 @@ function campaignion_email_protest_type_uuid_features_default_content() {
         'from_address' => 'default',
         'template' => '<p>Hi [submission:values:first_name],</p>
 <p>Thank you for supporting us!</p>
-<p>Remember: sharing is caring :-)</p>
 <p>Have a great day!<br>
 	Your Supporter Service Team</p>
 ',

--- a/modules/campaignion_email_to_target_type/campaignion_email_to_target_type.features.uuid_node.inc
+++ b/modules/campaignion_email_to_target_type/campaignion_email_to_target_type.features.uuid_node.inc
@@ -152,7 +152,6 @@ function campaignion_email_to_target_type_uuid_features_default_content() {
         'from_address' => 'default',
         'template' => '<p>Hi [submission:values:first_name],</p>
 <p>Thank you for supporting us!</p>
-<p>Remember: sharing is caring :-)</p>
 <p>Have a great day!<br>
 	Your Supporter Service Team</p>
 ',

--- a/modules/campaignion_flexible_form/campaignion_flexible_form_templates/campaignion_flexible_form_templates.features.uuid_node.inc
+++ b/modules/campaignion_flexible_form/campaignion_flexible_form_templates/campaignion_flexible_form_templates.features.uuid_node.inc
@@ -127,7 +127,6 @@ function campaignion_flexible_form_templates_uuid_features_default_content() {
         'from_address' => 'default',
         'template' => '<p>Hi [submission:values:first_name],</p>
 <p>Thank you for supporting us!</p>
-<p>Remember: sharing is caring :-)</p>
 <p>Have a great day!<br>
 	Your Supporter Service Team</p>
 ',

--- a/modules/campaignion_petition/campaignion_petition_templates/campaignion_petition_templates.features.uuid_node.inc
+++ b/modules/campaignion_petition/campaignion_petition_templates/campaignion_petition_templates.features.uuid_node.inc
@@ -142,7 +142,6 @@ function campaignion_petition_templates_uuid_features_default_content() {
         'from_address' => 'default',
         'template' => '<p>Hi [submission:values:first_name],</p>
 <p>Thank you for supporting us!</p>
-<p>Remember: sharing is caring :-)</p>
 <p>Have a great day!<br>
 	Your Supporter Service Team</p>
 


### PR DESCRIPTION
Thank you emails are perfectly GDPR compliant if they're handled as administrative emails and not marketing. A strict interpretation of 'marketing' would mean you couldn't include another ask like share.
We need to change the default text in the TY emails so it's purely administrative.