### PR TITLE
Remove old-style newsletter checkboxes.

### DIFF
--- a/campaignion_starterkit_uk.info
+++ b/campaignion_starterkit_uk.info
@@ -45,6 +45,7 @@ dependencies[] = campaignion_flexible_form_templates
 dependencies[] = campaignion_form_builder
 dependencies[] = campaignion_manage
 dependencies[] = campaignion_news
+dependencies[] = campaignion_newsletters
 dependencies[] = campaignion_node_ux
 dependencies[] = campaignion_petition
 dependencies[] = campaignion_petition_templates


### PR DESCRIPTION
This simply enables campaignion_newsletters by default. There is no email_newsletter checkbox in the default form templates.