### PR TITLE
Fix region_content_bottom_default excluding itself.

### DIFF
--- a/modules/campaignion_context/campaignion_context.context.inc
+++ b/modules/campaignion_context/campaignion_context.context.inc
@@ -52,7 +52,7 @@ function campaignion_context_context_default_contexts() {
   $context->conditions = array(
     'context' => array(
       'values' => array(
-        '~region_content_bottom_default' => '~region_content_bottom_default',
+        '~region_content_bottom_overwrite*' => '~region_content_bottom_overwrite*',
       ),
     ),
   );


### PR DESCRIPTION
This creates a circular dependency between contexts which means the result is not well definied.